### PR TITLE
Rename `From` to `ClientId`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ mod server;
 
 pub use self::client::RpcClient;
 pub use self::connection::{Connection, ConnectionState};
-pub use self::server::{From, RpcServer};
+pub use self::server::{ClientId, RpcServer};
 
 #[cfg(test)]
 mod tests {

--- a/src/server.rs
+++ b/src/server.rs
@@ -228,8 +228,22 @@ where
 }
 
 /// Identifier of a client.
-#[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(from = "usize", into = "usize")]
 pub struct ClientId {
     token: Token,
-    // TODO: Add connection_seqno (u64) to avoid ABA problem
+}
+
+impl From<usize> for ClientId {
+    fn from(value: usize) -> Self {
+        Self {
+            token: Token(value),
+        }
+    }
+}
+
+impl From<ClientId> for usize {
+    fn from(value: ClientId) -> Self {
+        value.token.0
+    }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -69,6 +69,13 @@ where
     }
 
     /// Takes a JSON-RPC request from the receive queue.
+    ///
+    /// # NOTE
+    ///
+    /// If you process the request asynchronously,
+    /// it is your responsibility to specify a sufficiently large
+    /// token space when calling [`RpcServer::start()`]
+    /// to prevent the ABA problem.
     pub fn try_recv(&mut self) -> Option<(ClientId, REQ)> {
         self.requests.pop_front()
     }


### PR DESCRIPTION
Copilot Summary
------------------------------

This pull request includes significant changes to the `RpcServer` implementation in the `src/server.rs` file, primarily focusing on renaming and refactoring for clarity and to address potential issues.

### Refactoring and Renaming:

* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L66-R66): Updated the `pub use` statement to export `ClientId` instead of `From`.
* [`src/server.rs`](diffhunk://#diff-48d27698cc708c7efe770fd897e4885efaa0a15cae30d54936068603ba03bbd9L27-R27): Renamed `From` to `ClientId` in the `requests` field of the `RpcServer` struct.
* [`src/server.rs`](diffhunk://#diff-48d27698cc708c7efe770fd897e4885efaa0a15cae30d54936068603ba03bbd9L72-R87): Updated the `try_recv` method to return `Option<(ClientId, REQ)>` instead of `Option<(From, REQ)>`.
* [`src/server.rs`](diffhunk://#diff-48d27698cc708c7efe770fd897e4885efaa0a15cae30d54936068603ba03bbd9L72-R87): Modified the `reply` method to accept `ClientId` instead of `From`.
* [`src/server.rs`](diffhunk://#diff-48d27698cc708c7efe770fd897e4885efaa0a15cae30d54936068603ba03bbd9L161-R168): Replaced `From` with `ClientId` in the `requests.push_back` call.

### Structural Improvements:

* [`src/server.rs`](diffhunk://#diff-48d27698cc708c7efe770fd897e4885efaa0a15cae30d54936068603ba03bbd9L223-R248): Redesigned `From` struct to `ClientId` with additional traits and serialization/deserialization support.