### PR TITLE
Fix to read as much as possible from a socket once a readable event is triggered

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -218,7 +218,7 @@ mod tests {
             }
         }
         assert!(success);
-        assert_eq!(0, server.connections().count());
+        assert_eq!(1, server.connections().count());
 
         Ok(())
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -161,8 +161,6 @@ where
                             }
                         };
                     let _ = c.send(poller, &response);
-                    c.close(poller);
-                    closed = true;
                     Ok(())
                 }
                 Ok(request) => {

--- a/src/server.rs
+++ b/src/server.rs
@@ -115,6 +115,7 @@ where
         let mut closed = false;
         connection.handle_event(poller, event, |c, poller| {
             match c.stream_mut().read_value::<REQ>() {
+                Err(e) if e.io_error_kind() == Some(std::io::ErrorKind::WouldBlock) => Err(e),
                 Err(e) if e.is_io() => {
                     c.close(poller);
                     closed = true;


### PR DESCRIPTION
Copilot Summary
------------------

This pull request includes several changes to the `src/connection.rs` and `src/server.rs` files to improve the handling of connection states and error management. The most important changes include modifying the `close` method to correctly set the connection state, changing the `handle_read` method to handle multiple read attempts, and updating error handling in the server.

Improvements to connection state handling:

* [`src/connection.rs`](diffhunk://#diff-68923d8302dccbcf4197d9a4d936226739cb7348ad30f173f7de2f301c23b0afL50-R56): Modified the `close` method to set the connection state to `Closed` after shutting down the stream.

Improvements to error management and handling:

* [`src/connection.rs`](diffhunk://#diff-68923d8302dccbcf4197d9a4d936226739cb7348ad30f173f7de2f301c23b0afL69-R70): Changed the `handle_read` method to use `FnMut` instead of `FnOnce` and to handle multiple read attempts until the connection state is `Closed`. [[1]](diffhunk://#diff-68923d8302dccbcf4197d9a4d936226739cb7348ad30f173f7de2f301c23b0afL69-R70) [[2]](diffhunk://#diff-68923d8302dccbcf4197d9a4d936226739cb7348ad30f173f7de2f301c23b0afL86-R97)
* [`src/server.rs`](diffhunk://#diff-48d27698cc708c7efe770fd897e4885efaa0a15cae30d54936068603ba03bbd9R118): Updated the error handling in the `where` clause to properly handle `WouldBlock` errors.